### PR TITLE
avoid name collisions with Queue and Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- Queue and Table are now ArduinoCIQueue and ArduinoCITable to avoid name collisions
 
 ### Deprecated
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,9 @@ Be prepared to write tests to accompany any code you would like to see merged.
 * `git add README.md CHANGELOG.md lib/arduino_ci/version.rb`
 * `git commit -m "vVERSION bump"`
 * `git tag -a vVERSION -m "Released version VERSION"`
+* `git stash save`
 * `gem build arduino_ci.gemspec`
+* `git stash pop`
 * `gem push arduino_ci-VERSION.gem`
 * `git push upstream`
 * `git push upstream --tags`

--- a/SampleProjects/TestSomething/test/queue.cpp
+++ b/SampleProjects/TestSomething/test/queue.cpp
@@ -3,7 +3,7 @@
 
 unittest(basic_queue_dequeue_and_size)
 {
-  Queue<int> q;
+  ArduinoCIQueue<int> q;
   int data[5] = {11, 22, 33, 44, 55};
 
   assertTrue(q.empty());
@@ -27,11 +27,11 @@ unittest(basic_queue_dequeue_and_size)
 
 unittest(copy_constructor)
 {
-  Queue<int> q;
+  ArduinoCIQueue<int> q;
   int data[5] = {11, 22, 33, 44, 55};
   for (int i = 0; i < 5; ++i) q.push(data[i]);
 
-  Queue<int> q2(q);
+  ArduinoCIQueue<int> q2(q);
 
   for (int i = 0; i < 5; ++i) {
     assertEqual(5 - i, q2.size());

--- a/SampleProjects/TestSomething/test/table.cpp
+++ b/SampleProjects/TestSomething/test/table.cpp
@@ -20,7 +20,7 @@ void setResult3(long l, int k, int v) {
 
 unittest(basic_table)
 {
-  Table<String, int> t;
+  ArduinoCITable<String, int> t;
   assertTrue(t.empty());
 
   int data[5] = {11, 22, 33, 44, 55};
@@ -47,7 +47,7 @@ unittest(basic_table)
 }
 
 unittest(iteration_no_arg) {
-  Table<int, int> t;
+  ArduinoCITable<int, int> t;
   for (int i = 0; i < 5; ++i) {
     results[i] = 0;
     t.add(i, 11 * (i + 1));
@@ -59,7 +59,7 @@ unittest(iteration_no_arg) {
 }
 
 unittest(iteration_one_arg) {
-  Table<int, int> t;
+  ArduinoCITable<int, int> t;
   for (int i = 0; i < 5; ++i) {
     results[i] = 0;
     t.add(i, 11 * (i + 1));

--- a/cpp/arduino/PinHistory.h
+++ b/cpp/arduino/PinHistory.h
@@ -7,8 +7,8 @@
 template <typename T>
 class PinHistory : public ObservableDataStream {
   private:
-    Queue<T> qIn;
-    Queue<T> qOut;
+    ArduinoCIQueue<T> qIn;
+    ArduinoCIQueue<T> qOut;
 
     void clear() {
       qOut.clear();
@@ -16,7 +16,7 @@ class PinHistory : public ObservableDataStream {
     }
 
     // enqueue ascii bits
-    void a2q(Queue<T> &q, String input, bool bigEndian, bool advertise) {
+    void a2q(ArduinoCIQueue<T> &q, String input, bool bigEndian, bool advertise) {
       // 8 chars at a time, form up
       for (int j = 0; j < input.length(); ++j) {
         for (int i = 0; i < 8; ++i) {
@@ -31,10 +31,10 @@ class PinHistory : public ObservableDataStream {
 
     // convert a queue to a string as if it was serial bits
     // start from offset, consider endianness
-    String q2a(const Queue<T> &q, unsigned int offset, bool bigEndian) const {
+    String q2a(const ArduinoCIQueue<T> &q, unsigned int offset, bool bigEndian) const {
       String ret = "";
 
-      Queue<T> q2(q);
+      ArduinoCIQueue<T> q2(q);
 
       while (offset) {
         q2.pop();
@@ -135,7 +135,7 @@ class PinHistory : public ObservableDataStream {
     // copy elements to an array, up to a given length
     // return the number of elements moved
     int toArray (T* arr, unsigned int length) const {
-      Queue<T> q2(qOut);
+      ArduinoCIQueue<T> q2(qOut);
 
       int ret = 0;
       for (int i = 0; i < length && q2.size(); ++i) {
@@ -149,7 +149,7 @@ class PinHistory : public ObservableDataStream {
     // see if the array matches the elements in the queue
     bool hasElements (T const * const arr, unsigned int length) const {
       int i;
-      Queue<T> q2(qOut);
+      ArduinoCIQueue<T> q2(qOut);
       for (i = 0; i < length && q2.size(); ++i) {
         if (q2.front() != arr[i]) return false;
         q2.pop();

--- a/cpp/arduino/ci/DeviceUsingBytes.h
+++ b/cpp/arduino/ci/DeviceUsingBytes.h
@@ -25,7 +25,7 @@
 class DeviceUsingBytes : public DataStreamObserver {
   public:
     String mMessage;
-    Table<String, String> mResponses;
+    ArduinoCITable<String, String> mResponses;
     GodmodeState* state;
 
 

--- a/cpp/arduino/ci/ObservableDataStream.h
+++ b/cpp/arduino/ci/ObservableDataStream.h
@@ -72,7 +72,7 @@ class DataStreamObserver {
 class ObservableDataStream
 {
   private:
-    Table<String, DataStreamObserver*> mObservers;
+    ArduinoCITable<String, DataStreamObserver*> mObservers;
     bool          mAdvertisingBit;
     unsigned char mAdvertisingByte;
 

--- a/cpp/arduino/ci/Queue.h
+++ b/cpp/arduino/ci/Queue.h
@@ -1,7 +1,7 @@
 #pragma once
 
 template <typename T>
-class Queue {
+class ArduinoCIQueue {
   private:
     struct Node {
       T data;
@@ -19,9 +19,9 @@ class Queue {
     }
 
   public:
-    Queue(): mNil() { init(); }
+    ArduinoCIQueue(): mNil() { init(); }
 
-    Queue(const Queue<T>& q) {
+    ArduinoCIQueue(const ArduinoCIQueue<T>& q) {
       init();
       for (Node* n = q.mFront; n; n = n->next) push(n->data);
     }
@@ -69,5 +69,5 @@ class Queue {
 
     void clear() { while (!empty()) pop(); }
 
-    ~Queue() { clear(); }
+    ~ArduinoCIQueue() { clear(); }
 };

--- a/cpp/arduino/ci/Table.h
+++ b/cpp/arduino/ci/Table.h
@@ -5,7 +5,7 @@
 // this is this stupidest table implementation ever but it's
 // an MVP for unit testing. O(n).
 template <typename K, typename V>
-class Table {
+class ArduinoCITable {
   private:
     struct Node {
       K key;
@@ -25,7 +25,7 @@ class Table {
     }
 
   public:
-    Table() : mNilK(), mNilV() { init(); }
+    ArduinoCITable() : mNilK(), mNilV() { init(); }
 
     // number of things in the table
     inline unsigned long size() const { return mSize; }
@@ -121,5 +121,5 @@ class Table {
       }
     }
 
-    ~Table() { clear(); }
+    ~ArduinoCITable() { clear(); }
 };


### PR DESCRIPTION
Use `ArduinoCI` prefix on the `Queue` and `Table` classes
