### PR TITLE
Fix for OSX compile errors

### DIFF
--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -73,6 +73,7 @@ inline unsigned int makeWord(unsigned char h, unsigned char l) { return (h << 8)
 
 #define word(...) makeWord(__VA_ARGS__)
 
-
-
-
+// audio 
+inline void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) { }
+inline void tone(uint8_t _pin, unsigned int frequency) { }
+inline void noTone(uint8_t _pin) { }

--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -74,6 +74,7 @@ inline unsigned int makeWord(unsigned char h, unsigned char l) { return (h << 8)
 #define word(...) makeWord(__VA_ARGS__)
 
 // audio 
+// TODO Add audio to GODMODE mock
 inline void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) { }
 inline void tone(uint8_t _pin, unsigned int frequency) { }
 inline void noTone(uint8_t _pin) { }

--- a/cpp/arduino/ArduinoDefines.h
+++ b/cpp/arduino/ArduinoDefines.h
@@ -89,3 +89,6 @@
 #define TIMER5B 17
 #define TIMER5C 18
 
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#define LED_BUILTIN 13
+#endif

--- a/cpp/arduino/HardwareSerial.h
+++ b/cpp/arduino/HardwareSerial.h
@@ -61,7 +61,7 @@ class HardwareSerial : public Stream, public ObservableDataStream
     inline size_t write(long n) { return write((uint8_t)n); }
     inline size_t write(unsigned int n) { return write((uint8_t)n); }
     inline size_t write(int n) { return write((uint8_t)n); }
-    // using Print::write; // pull in write(str) and write(buf, size) from Print
+    using Print::write; // pull in write(str) and write(buf, size) from Print
     operator bool() { return true; }
 
 };

--- a/cpp/arduino/Print.h
+++ b/cpp/arduino/Print.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdio.h>
+#include <avr/pgmspace.h>
 #include "WString.h"
 
 #define DEC 10

--- a/cpp/arduino/WString.h
+++ b/cpp/arduino/WString.h
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <algorithm>
 #include <iostream>
+#include <cmath>
 #include "AvrMath.h"
 #include "WCharacter.h"
 


### PR DESCRIPTION
Fix for g++ compile errors under OSX.

`/Library/Ruby/Gems/2.3.0/gems/arduino_ci-0.1.7/cpp/arduino/Print.h:57:86: error: unknown type name 'PGM_P'`
`/Library/Ruby/Gems/2.3.0/gems/arduino_ci-0.1.7/cpp/arduino/WString.h:39:16: error: no member named 'isnan' in namespace 'std'`

