### PR TITLE
Fix OSX compilation and other C++-related issues

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -4,7 +4,7 @@
  - `ruby -v`:
  - `bundle -v`:
  - `bundle info arduino_ci`:
- - `gcc -v`:
+ - `g++ -v`:
  - Arduino IDE version:
  - URL of failing Travis CI job:
  - URL of your Arduino project:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Compile errors / portability issues in `WString.h` and `Print.h`, first reported by `dfrencham` on GitHub
+- Compile errors / inheritance issues in `Print.h` and `Stream.h`, first reported by `dfrencham` on GitHub
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Definition of `LED_BUILTIN`, first reported by `dfrencham` on GitHub
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Compile errors / portability issues in `WString.h` and `Print.h`, first reported by `dfrencham` on GitHub
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Definition of `LED_BUILTIN`, first reported by `dfrencham` on GitHub
+- Stubs for `tone` and `noTone`, first suggested by `dfrencham` on GitHub
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Definition of `LED_BUILTIN`, first reported by `dfrencham` on GitHub
 - Stubs for `tone` and `noTone`, first suggested by `dfrencham` on GitHub
+- Ability to specify multiple compilers for unit testing
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Compile errors / portability issues in `WString.h` and `Print.h`, first reported by `dfrencham` on GitHub
 - Compile errors / inheritance issues in `Print.h` and `Stream.h`, first reported by `dfrencham` on GitHub
+- Print functions for int, double, long, etc
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,10 @@ For your unit tests, in addition to setting specific libraries and platforms, yo
 
 ```yaml
 unittest:
+  compilers:
+    - g++      # default
+    - g++-4.9
+    - g++-7
   testfiles:
     select:
       - "*-*.*"

--- a/SampleProjects/DoSomething/Gemfile.lock
+++ b/SampleProjects/DoSomething/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/ikatz/Development/non-wayfair/arduino_ci
   specs:
-    arduino_ci (0.0.1)
+    arduino_ci (0.1.7)
       os (~> 1.0)
 
 GEM

--- a/SampleProjects/TestSomething/.arduino-ci.yml
+++ b/SampleProjects/TestSomething/.arduino-ci.yml
@@ -2,3 +2,7 @@ unittest:
   platforms:
     - uno
     - due
+
+unittest:
+  compilers:
+    - g++

--- a/SampleProjects/TestSomething/test/serial.cpp
+++ b/SampleProjects/TestSomething/test/serial.cpp
@@ -43,6 +43,21 @@ unittest(serial_ports)
     assertEqual("bcdefg", state->serialPort[0].dataOut);
   }
 
+  unittest(all_serial_writes)
+  {
+    GodmodeState* state = GODMODE();
+    state->serialPort[0].dataIn = "";
+    state->serialPort[0].dataOut = "";
+
+    char str[4] = "xyz";
+    Serial.write(reinterpret_cast<const uint8_t *>(str ), 3);
+    Serial.print((int)1);
+    Serial.print((long)2);
+    Serial.print((double)3.4);
+    Serial.print((char)'a');
+    Serial.print("b");
+  }
+
 #endif
 
 unittest_main()

--- a/SampleProjects/TestSomething/test/serial.cpp
+++ b/SampleProjects/TestSomething/test/serial.cpp
@@ -56,6 +56,7 @@ unittest(serial_ports)
     Serial.print((double)3.4);
     Serial.print((char)'a');
     Serial.print("b");
+    assertEqual("xyz123.4000000000ab", state->serialPort[0].dataOut);
   }
 
 #endif

--- a/cpp/arduino/ArduinoDefines.h
+++ b/cpp/arduino/ArduinoDefines.h
@@ -89,3 +89,6 @@
 #define TIMER5B 17
 #define TIMER5C 18
 
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+  #define LED_BUILTIN 13
+#endif

--- a/cpp/arduino/Godmode.h
+++ b/cpp/arduino/Godmode.h
@@ -91,6 +91,11 @@ void analogWrite(uint8_t, int);
 #define analogReadResolution(...) _NOP()
 #define analogWriteResolution(...) _NOP()
 
+// TODO: issue #26 to track the commanded state here
+inline void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0) {}
+inline void tone(uint8_t _pin, unsigned int frequency) {}
+inline void noTone(uint8_t _pin) {}
+
 
 GodmodeState* GODMODE();
 

--- a/cpp/arduino/HardwareSerial.h
+++ b/cpp/arduino/HardwareSerial.h
@@ -57,11 +57,8 @@ class HardwareSerial : public Stream, public ObservableDataStream
       return 1;
     }
 
-    inline size_t write(unsigned long n) { return write((uint8_t)n); }
-    inline size_t write(long n) { return write((uint8_t)n); }
-    inline size_t write(unsigned int n) { return write((uint8_t)n); }
-    inline size_t write(int n) { return write((uint8_t)n); }
-    // using Print::write; // pull in write(str) and write(buf, size) from Print
+    // https://stackoverflow.com/a/4271276
+    using Print::write; // pull in write(str) and write(buf, size) from Print
     operator bool() { return true; }
 
 };

--- a/cpp/arduino/Print.h
+++ b/cpp/arduino/Print.h
@@ -33,38 +33,38 @@ class Print
     virtual size_t write(uint8_t) = 0;
     size_t write(const char *str) { return str == NULL ? 0 : write((const uint8_t *)str, String(str).length()); }
 
-
     virtual size_t write(const uint8_t *buffer, size_t size) {
       size_t n;
       for (n = 0; size && write(*buffer++) && ++n; --size);
       return n;
     }
+
     size_t write(const char *buffer, size_t size) { return write((const uint8_t *)buffer, size); }
 
-    size_t print(const String &s)                { return write(s.c_str(), s.length()); }
-    size_t print(const __FlashStringHelper *str) { return print(reinterpret_cast<PGM_P>(str)); }
-    size_t print(const char* str)                { return print(String(str)); }
-    size_t print(char c)                         { return print(String(c)); }
-    size_t print(unsigned char b, int base)      { return print(String(b, base)); }
-    size_t print(int n, int base)                { return print(String(n, base)); }
-    size_t print(unsigned int n, int base)       { return print(String(n, base)); }
-    size_t print(long n, int base)               { return print(String(n, base)); }
-    size_t print(unsigned long n, int base)      { return print(String(n, base)); }
-    size_t print(double n, int digits)           { return print(String(n, digits)); }
-    size_t print(const Printable& x)             { return x.printTo(*this); }
+    size_t print(const String &s)                 { return write(s.c_str(), s.length()); }
+    size_t print(const __FlashStringHelper *str)  { return print(reinterpret_cast<PGM_P>(str)); }
+    size_t print(const char* str)                 { return print(String(str)); }
+    size_t print(char c)                          { return print(String(c)); }
+    size_t print(unsigned char b, int base = DEC) { return print(String(b, base)); }
+    size_t print(int n,           int base = DEC) { return print(String(n, base)); }
+    size_t print(unsigned int n,  int base = DEC) { return print(String(n, base)); }
+    size_t print(long n,          int base = DEC) { return print(String(n, base)); }
+    size_t print(unsigned long n, int base = DEC) { return print(String(n, base)); }
+    size_t print(double n,        int base = DEC) { return print(String(n, base)); }
+    size_t print(const Printable& x)              { return x.printTo(*this); }
 
-    size_t println(void)                           { return print("\r\n"); }
-    size_t println(const String &s)                { return print(s) + println(); }
-    size_t println(const __FlashStringHelper *str) { return println(reinterpret_cast<PGM_P>(str)); }
-    size_t println(const char* c)                  { return println(String(c)); }
-    size_t println(char c)                         { return println(String(c)); }
-    size_t println(unsigned char b, int base)      { return println(String(b, base)); }
-    size_t println(int num, int base)              { return println(String(num, base)); }
-    size_t println(unsigned int num, int base)     { return println(String(num, base)); }
-    size_t println(long num, int base)             { return println(String(num, base)); }
-    size_t println(unsigned long num, int base)    { return println(String(num, base)); }
-    size_t println(double num, int digits)         { return println(String(num, digits)); }
-    size_t println(const Printable& x)             { return print(x) + println(); }
+    size_t println(void)                              { return print("\r\n"); }
+    size_t println(const String &s)                   { return print(s) + println(); }
+    size_t println(const __FlashStringHelper *str)    { return println(reinterpret_cast<PGM_P>(str)); }
+    size_t println(const char* c)                     { return println(String(c)); }
+    size_t println(char c)                            { return println(String(c)); }
+    size_t println(unsigned char b,   int base = DEC) { return println(String(b, base)); }
+    size_t println(int num,           int base = DEC) { return println(String(num, base)); }
+    size_t println(unsigned int num,  int base = DEC) { return println(String(num, base)); }
+    size_t println(long num,          int base = DEC) { return println(String(num, base)); }
+    size_t println(unsigned long num, int base = DEC) { return println(String(num, base)); }
+    size_t println(double num,        int base = DEC) { return println(String(num, base)); }
+    size_t println(const Printable& x)                { return print(x) + println(); }
 
     virtual void flush() { }
 

--- a/cpp/arduino/Print.h
+++ b/cpp/arduino/Print.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdio.h>
+#include <avr/pgmspace.h>
 #include "WString.h"
 
 #define DEC 10

--- a/cpp/arduino/Stream.h
+++ b/cpp/arduino/Stream.h
@@ -56,10 +56,10 @@ class Stream : public Print
       return ret;
     }
 
+    // https://stackoverflow.com/a/4271276
     using Print::write;
 
     virtual size_t write(uint8_t aChar) { mGodmodeDataIn->append(String((char)aChar)); return 1; }
-
 
     Stream() {
       mTimeoutMillis = 1000;

--- a/cpp/arduino/WString.h
+++ b/cpp/arduino/WString.h
@@ -9,6 +9,22 @@
 
 typedef std::string string;
 
+// work around some portability issues
+#if defined(__clang__)
+  #define ARDUINOCI_ISNAN ::isnan
+  #define ARDUINOCI_ISINF ::isinf
+#elif defined(__GNUC__) || defined(__GNUG__)
+  #define ARDUINOCI_ISNAN std::isnan
+  #define ARDUINOCI_ISINF std::isinf
+#elif defined(_MSC_VER)
+  // TODO: no idea
+  #define ARDUINOCI_ISNAN ::isnan
+  #define ARDUINOCI_ISINF ::isinf
+#else
+  #define ARDUINOCI_ISNAN ::isnan
+  #define ARDUINOCI_ISINF ::isinf
+#endif
+
 class __FlashStringHelper;
 #define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
 
@@ -36,8 +52,8 @@ class String: public string
 
     static string dtoas(double val, int decimalPlaces) {
       double r = 0.5 * pow(0.1, decimalPlaces); // make sure that integer truncation will properly round
-      if (std::isnan(val)) return "nan";
-      if (std::isinf(val)) return "inf";
+      if (ARDUINOCI_ISNAN(val)) return "nan";
+      if (ARDUINOCI_ISINF(val)) return "inf";
       val += val > 0 ? r : -r;
       if (val > 4294967040.0) return "ovf";
       if (val <-4294967040.0) return "ovf";

--- a/lib/arduino_ci/ci_config.rb
+++ b/lib/arduino_ci/ci_config.rb
@@ -25,6 +25,7 @@ COMPILE_SCHEMA = {
 }.freeze
 
 UNITTEST_SCHEMA = {
+  compilers: Array,
   platforms: Array,
   libraries: Array,
   testfiles: {
@@ -195,6 +196,13 @@ module ArduinoCI
     def package_url(package)
       return nil if @package_info[package].nil?
       @package_info[package][:url]
+    end
+
+    # compilers to build (unit tests) with
+    # @return [Array<String>] The compiler binary names (e.g. g++) to build with
+    def compilers_to_use
+      return [] if @unittest_info[:compilers].nil?
+      @unittest_info[:compilers]
     end
 
     # platforms to build [the examples on]

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -107,10 +107,9 @@ module ArduinoCI
     end
 
     # wrapper for the GCC command
-    def run_gcc(*args, **kwargs)
-      full_args = ["g++"] + args
+    def run_gcc(gcc_binary, *args, **kwargs)
+      full_args = [gcc_binary] + args
       @last_cmd = " $ #{full_args.join(' ')}"
-
       ret = Host.run_and_capture(*full_args, **kwargs)
       @last_err = ret[:err]
       @last_out = ret[:out]
@@ -119,8 +118,8 @@ module ArduinoCI
 
     # Return the GCC version
     # @return [String] the version reported by `gcc -v`
-    def gcc_version
-      return nil unless run_gcc("-v")
+    def gcc_version(gcc_binary)
+      return nil unless run_gcc(gcc_binary, "-v")
       @last_err
     end
 
@@ -183,7 +182,7 @@ module ArduinoCI
     # @param aux_libraries [String] The external Arduino libraries required by this project
     # @param ci_gcc_config [Hash] The GCC config object
     # @return [String] path to the compiled test executable
-    def build_for_test_with_configuration(test_file, aux_libraries, ci_gcc_config)
+    def build_for_test_with_configuration(test_file, aux_libraries, gcc_binary, ci_gcc_config)
       base = File.basename(test_file)
       executable = File.expand_path("unittest_#{base}.bin")
       File.delete(executable) if File.exist?(executable)
@@ -192,7 +191,7 @@ module ArduinoCI
         test_args(aux_libraries, ci_gcc_config),
         [test_file],
       ].flatten(1)
-      return nil unless run_gcc(*args)
+      return nil unless run_gcc(gcc_binary, *args)
       artifacts << executable
       executable
     end

--- a/misc/default.yml
+++ b/misc/default.yml
@@ -80,6 +80,8 @@ compile:
     - leonardo
 
 unittest:
+  compilers:
+    - g++
   libraries: ~
   platforms:
     - uno

--- a/spec/ci_config_spec.rb
+++ b/spec/ci_config_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe ArduinoCI::CIConfig do
       expect(default_config.platforms_to_unittest).to match(["uno", "due", "zero", "leonardo"])
       expect(default_config.aux_libraries_for_build).to match([])
       expect(default_config.aux_libraries_for_unittest).to match([])
+
+      expect(default_config.compilers_to_use).to match(["g++"])
     end
   end
 
@@ -63,6 +65,9 @@ RSpec.describe ArduinoCI::CIConfig do
       expect(combined_config.platforms_to_unittest).to match(["bogo"])
       expect(combined_config.aux_libraries_for_build).to match(["Adafruit FONA Library"])
       expect(combined_config.aux_libraries_for_unittest).to match(["abc123", "def456"])
+
+      expect(combined_config.compilers_to_use).to match(["g++", "g++-7"])
+
     end
   end
 

--- a/spec/cpp_library_spec.rb
+++ b/spec/cpp_library_spec.rb
@@ -62,10 +62,12 @@ RSpec.describe ArduinoCI::CppLibrary do
     test_files = cpp_library.test_files
     test_files.each do |path|
       expected = path.include?("good")
-      it "tests #{File.basename(path)} expecting #{expected}" do
-        exe = cpp_library.build_for_test_with_configuration(path, [], config.gcc_config("uno"))
-        expect(exe).not_to be nil
-        expect(cpp_library.run_test_file(exe)).to eq(expected)
+      config.compilers_to_use.each do |compiler|
+        it "tests #{File.basename(path)} with #{compiler} expecting #{expected}" do
+          exe = cpp_library.build_for_test_with_configuration(path, [], compiler, config.gcc_config("uno"))
+          expect(exe).not_to be nil
+          expect(cpp_library.run_test_file(exe)).to eq(expected)
+        end
       end
     end
   end

--- a/spec/testsomething_unittests_spec.rb
+++ b/spec/testsomething_unittests_spec.rb
@@ -26,32 +26,40 @@ RSpec.describe "TestSomething C++" do
       expect(allowed_files.empty?).to be false
     end
 
+    it "has at least one compiler defined" do
+      expect(config.compilers_to_use.length.zero?).to be(false)
+    end
+
     test_files = config.allowable_unittest_files(cpp_library.test_files)
     test_files.each do |path|
       tfn = File.basename(path)
-      context "file #{tfn}" do
 
-        before(:all) do
-          @exe = cpp_library.build_for_test_with_configuration(path, [], config.gcc_config("uno"))
-        end
+      config.compilers_to_use.each do |compiler|
 
-        # extra debug for c++ failures
-        after(:each) do |example|
-          if example.exception
-            puts "Last command: #{cpp_library.last_cmd}"
-            puts "========== Stdout:"
-            puts cpp_library.last_out
-            puts "========== Stderr:"
-            puts cpp_library.last_err
+        context "file #{tfn} (using #{compiler})" do
+
+          before(:all) do
+            @exe = cpp_library.build_for_test_with_configuration(path, [], compiler, config.gcc_config("uno"))
           end
-        end
 
-        it "#{tfn} builds successfully" do
-          expect(@exe).not_to be nil
-        end
-        it "#{tfn} passes tests" do
-          skip "Can't run the test program because it failed to build" if @exe.nil?
-          expect(cpp_library.run_test_file(@exe)).to_not be_falsey
+          # extra debug for c++ failures
+          after(:each) do |example|
+            if example.exception
+              puts "Last command: #{cpp_library.last_cmd}"
+              puts "========== Stdout:"
+              puts cpp_library.last_out
+              puts "========== Stderr:"
+              puts cpp_library.last_err
+            end
+          end
+
+          it "#{tfn} builds successfully" do
+            expect(@exe).not_to be nil
+          end
+          it "#{tfn} passes tests" do
+            skip "Can't run the test program because it failed to build" if @exe.nil?
+            expect(cpp_library.run_test_file(@exe)).to_not be_falsey
+          end
         end
       end
     end

--- a/spec/yaml/o1.yaml
+++ b/spec/yaml/o1.yaml
@@ -32,6 +32,9 @@ compile:
     - esp8266
 
 unittest:
+  compilers:
+    - g++
+    - g++-7
   testfiles:
     select:
       - "*-*.*"


### PR DESCRIPTION
## Highlights from `CHANGELOG.md`

* Addresses problems raised in #24 by @dfrencham
* Preprocessor detection of `g++` version and appropriate reaction for `isnan` / `isinf`
* Defines `LED_BUILTIN`
* Fixes `pgmspace` in `Print.h`
* See CHANGELOG.md for more


## Issues Fixed

* Fixes #25 
